### PR TITLE
Prevent `None` to be displayed from translations

### DIFF
--- a/fuuk/templates/flatpages/base4F4.html
+++ b/fuuk/templates/flatpages/base4F4.html
@@ -37,8 +37,8 @@
 {% endblock %}
 
 {% block content %}
-<h1>{{ flatpage.title }}</h1>
+<h1>{{ flatpage.title_any }}</h1>
 <p>
-    {{ flatpage.content|textile }}
+    {{ flatpage.content_any|textile }}
 </p>
 {% endblock %}

--- a/fuuk/templates/flatpages/default.html
+++ b/fuuk/templates/flatpages/default.html
@@ -1,8 +1,8 @@
 {% extends "base_site.html" %}
 {% load markup %}
 {% block content %}
-<h1>{{ flatpage.title }}</h1>
+<h1>{{ flatpage.title_any }}</h1>
 <p>
-{{ flatpage.content|textile }}
+{{ flatpage.content_any|textile }}
 </p>
 {% endblock %}

--- a/fuuk/templates/flatpages/front.html
+++ b/fuuk/templates/flatpages/front.html
@@ -4,9 +4,9 @@
 <a href="http://www.cuni.cz/" target="blank">{% trans "Charles University in Prague" %}</a> &gt;
 <a href="http://www.mff.cuni.cz/" target="blank">{% trans "Faculty of Mathematics and Physics" %}</a> &gt;
 <a href="http://www.mff.cuni.cz/fakulta/struktura/fuuk.htm" target="blank">{% trans "Institute of Physics" %}</a>
-<h1>{{ flatpage.title }}</h1>
+<h1>{{ flatpage.title_any }}</h1>
 <p>
-{{ flatpage.content|textile }}
+{{ flatpage.content_any|textile }}
 {% if news_list %}
     <div id="akt-new">
         <h1>{% trans "News" %}:</h1>


### PR DESCRIPTION
In several places 'None' is displayed if translation is missing.