### PR TITLE
Update administration

### DIFF
--- a/fuuk/people/admin/__init__.py
+++ b/fuuk/people/admin/__init__.py
@@ -2,8 +2,8 @@ from django.contrib import admin
 
 from fuuk.people.admin.options import PlaceAdmin, DepartmentAdmin, PersonAdmin, HumanAdmin, CourseAdmin, AttachmentAdmin, \
     GrantAdmin, ThesisAdmin, AgencyAdmin, NewsAdmin, \
-    ArticleAdmin, ArticleBookAdmin, ArticleArticleAdmin, ArticleConferenceAdmin
-from fuuk.people.models import Department, Place, Human, Person, Course, Attachment, Grant, Article, Author, Thesis, Agency, \
+    ArticleBookAdmin, ArticleArticleAdmin, ArticleConferenceAdmin
+from fuuk.people.models import Department, Place, Human, Person, Course, Attachment, Grant, Author, Thesis, Agency, \
     ArticleBook, ArticleArticle, ArticleConference, News
 
 
@@ -14,7 +14,6 @@ admin.site.register(Human, HumanAdmin)
 admin.site.register(Course, CourseAdmin)
 admin.site.register(Attachment, AttachmentAdmin)
 admin.site.register(Grant, GrantAdmin)
-admin.site.register(Article, ArticleAdmin)
 admin.site.register(Thesis, ThesisAdmin)
 admin.site.register(Agency, AgencyAdmin)
 admin.site.register(News, NewsAdmin)

--- a/fuuk/people/models/course.py
+++ b/fuuk/people/models/course.py
@@ -18,8 +18,8 @@ class Course(MultilingualModel):
 
     class Translation:
         name = models.CharField(max_length=200)
-        annotation = models.CharField(max_length=500, blank=True, null=True)
-        note = models.CharField(max_length=200, blank=True, null=True)
+        annotation = models.TextField(blank=True, null=True)
+        note = models.TextField(blank=True, null=True)
 
     class Meta:
         app_label = 'people'

--- a/fuuk/people/models/news.py
+++ b/fuuk/people/models/news.py
@@ -18,12 +18,11 @@ class News(MultilingualModel):
 
     class Meta:
         app_label = "people"
-        ordering = ('end',)
         verbose_name_plural = "News"
 
     def __unicode__(self):
         return self.title or u""
-    
+
     def clean(self):
         if self.start > self.end:
             raise ValidationError('The event cant end before it starts.')

--- a/fuuk/people/models/person.py
+++ b/fuuk/people/models/person.py
@@ -52,7 +52,6 @@ class Human(MultilingualModel):
 
     class Meta:
         app_label = 'people'
-        ordering = ('nickname',)
 
     def __unicode__(self):
         return self.nickname or u""
@@ -80,7 +79,6 @@ class Person(models.Model):
 
     class Meta:
         app_label = 'people'
-        ordering = ('last_name',)
         unique_together = (
             ('first_name', 'last_name', 'type'),
         )


### PR DESCRIPTION
Remove administration of Articles, it should be only modified using Publications proxies.

Add search fields throughout the administration.

News: 
- Default sorting should be by end, but from newest.
- Add filter for end 

Courses:
- Change Annotation to Text Area instead of Text field
